### PR TITLE
Fix #29

### DIFF
--- a/TOMsPlugin/manageRestrictionDetails.py
+++ b/TOMsPlugin/manageRestrictionDetails.py
@@ -245,7 +245,6 @@ class ManageRestrictionDetails(RestrictionTypeUtilsMixin):
                         self.restrictionTransaction,
                     )  # connects signals
 
-                    dialog.setEnabled(UserPermission.WRITE)
                     dialog.show()
 
             else:

--- a/TOMsPlugin/restrictionTypeUtilsClass.py
+++ b/TOMsPlugin/restrictionTypeUtilsClass.py
@@ -36,7 +36,7 @@ from qgis.PyQt.QtWidgets import (
 )
 from qgis.utils import iface
 
-from .constants import ProposalStatus, RestrictionAction
+from .constants import ProposalStatus, RestrictionAction, UserPermission
 from .core.tomsMessageLog import TOMsMessageLog
 from .generateGeometryUtils import GenerateGeometryUtils
 from .ui.tomsCamera import FormCamera
@@ -666,6 +666,13 @@ class RestrictionTypeUtilsMixin:
     def onSaveRestrictionDetails(
         self, currRestriction, currRestrictionLayer, dialog, restrictionTransaction
     ):
+        if not UserPermission.WRITE:
+            QMessageBox.warning(
+                None,
+                "Read Only",
+                "Nothing will be saved because you only have read access",
+            )
+            return
         TOMsMessageLog.logMessage(
             "In onSaveRestrictionDetails: "
             + str(currRestriction.attribute("GeometryID")),


### PR DESCRIPTION
Rather than deactivating the form completely, rely on QGIS because the OK button is disabled in read only mode.

I added a double check: if a read-only user finds a hack to enable the OK button, clicking OK will pop up a message saying that no change will be done.